### PR TITLE
Benchmarks: fix out by one error

### DIFF
--- a/benchmarks/smack-regressions/functions/closure.rs
+++ b/benchmarks/smack-regressions/functions/closure.rs
@@ -10,7 +10,7 @@ where
 
 pub fn main() {
     let mut num = verifier::nondet!(5i32);
-    verifier::assume!(num <= std::i32::MAX - 5); // avoid overflow
+    verifier::assume!(num <= std::i32::MAX - 6); // avoid overflow
     let original_num = num;
     {
         let mut add_num = |x: i32| num += x;


### PR DESCRIPTION
The assumption had a out-by-one error resulting in an overflow