### PR TITLE
KLEE support

### DIFF
--- a/benchmarks/regtest.py
+++ b/benchmarks/regtest.py
@@ -242,7 +242,7 @@ def main():
         continue
 
       # build up the subprocess command
-      cmd = ['/Users/zrakamaric/projects/rust-benchmarks/benchmarks/run-mirai', test]
+      cmd = ['./run-mirai', test]
       name = path.splitext(path.basename(test))[0]
       r = p.apply_async(process_test,
             args=(cmd, test, meta['expect'], args.log_path,),

--- a/benchmarks/run-mirai
+++ b/benchmarks/run-mirai
@@ -1,6 +1,163 @@
-#!/bin/zsh
+#!/usr/bin/env python3
 
-export DYLD_LIBRARY_PATH=/Users/zrakamaric/.rustup/toolchains/nightly-2020-02-17-x86_64-apple-darwin/lib/
+import atexit
+import os
+import re
+import subprocess
+import sys
+import tempfile
 
-mirai $1 --extern verifier=/Users/zrakamaric/projects/rust-benchmarks/verifier/target/debug/deps/libverifier-1100ff06192add03.rlib --extern mirai_annotations=/Users/zrakamaric/projects/rust-benchmarks/verifier/target/debug/deps/libmirai_annotations-da502f6410e13cae.rlib
+# legal responses from this script
+# (to match the regtest.py script)
+status_timeout   = "SMACK timed out"
+status_verified  = None
+status_error     = "false verification condition"
+status_overflow  = "with overflow"
+status_reachable = "statement is reachable"
+status_unknown   = "unknown result" # can be any string you like
 
+# This "verifier" was used for debugging the interface to regtest.py but
+# is not used anymore.
+#
+# It cheats at verification by just looking at the filename to decide
+# what to report.
+# This was surprisingly accurate :-)
+def runtest_cheat(test):
+  status = status_verified
+  if "fail" in test: status = status_error
+  if "overflow" in test: status = status_overflow
+  return status
+
+# Verbosity control flag
+verbose = False
+
+# This verifier compiles a Rust file and uses KLEE to detect violations
+def runtest_honest(test):
+  if verbose: print(f"Verifying {test}")
+
+  # First, we have to construct a wrapper function that does some
+  # initialization and then calls main.
+  # We attach that to the end of the file being tested.
+  patched_file = tempfile.NamedTemporaryFile(suffix=".rs", dir=".", delete=False).name
+  atexit.register(os.remove, patched_file)
+  wrapper_function = '''
+
+    #[no_mangle]
+    pub extern "C" fn verifier_main() {
+        verifier::set_panic_hook();
+        main();
+    }
+
+  '''
+  concat_file(test, wrapper_function, patched_file)
+
+  if verbose: print(f"  Patching {test}")
+  # Second, we compile and link the patched file using LTO to generate the entire
+  # application in a single LLVM file
+  if verbose: print(f"  Compiling {test}")
+  llfile = tempfile.NamedTemporaryFile(suffix=".ll", dir=".", delete=False).name
+  atexit.register(os.remove, llfile)
+  status = rustc(patched_file, llfile)
+  if status is not None: return status
+
+  # Third, we run KLEE and sift through the KLEE output to generate
+  # an appropriate status string
+  if verbose: print(f"  Running KLEE to verify function")
+  status = klee(llfile, "verifier_main")
+  if status is not None: return status
+
+  # If nothing went wrong, report successful verification
+  # (But we are using symbolic execution which may not explore all paths
+  # so this really means that no bugs have been found.)
+  return status_verified
+
+def concat_file(infile, suffix, outfile):
+  with open(outfile, "w") as output_file:
+    with open(infile, "r") as input_file:
+      x = input_file.read()
+      print(x, file=output_file)
+      print(suffix, file=output_file)
+
+
+def rustc(rsfile, llfile):
+  verifier = "../verifier/target/debug/libverifier.rlib"
+  process = subprocess.Popen(['rustc',
+                              '--extern', f"verifier={verifier}",
+                              '--emit=llvm-ir',
+                              '-C', 'linker=true',
+                              '-C', 'panic=abort',
+                              '-C', 'lto',
+                              '-W', 'arithmetic-overflow',
+                              '--cfg', 'feature="verifier-klee"',
+                              '-o', llfile,
+                              rsfile],
+                             stdout=subprocess.PIPE, 
+                             stderr=subprocess.PIPE)
+  if verbose: print("    ", " ".join(process.args))
+  stdout, stderr = process.communicate()
+  if process.returncode != 0:
+    print("Couldn't compile")
+    print(process.args)
+    if verbose:
+        print(stdout.decode("utf-8"))
+        print(stderr.decode("utf-8"))
+    return status_unknown
+  return None
+
+def klee(llfile, entry):
+  process = subprocess.Popen(['klee',
+                              '--entry-point='+entry,
+                              '--exit-on-error',
+                              '--silent-klee-assume',
+                              llfile],
+                             stdout=subprocess.PIPE, 
+                             stderr=subprocess.PIPE)
+  stdout, stderr = process.communicate()
+
+  if stdout: print(stdout.decode("utf-8"))
+  for l in stderr.splitlines():
+    if l.startswith(b"KLEE: output directory"):
+      pass
+    elif l.startswith(b"KLEE: Using"):
+      pass
+    elif l.startswith(b"warning: Linking two modules of different data layouts"):
+      pass
+    elif l.startswith(b"KLEE: WARNING:"):
+      pass
+    elif l.startswith(b"KLEE: WARNING ONCE:"):
+      pass
+    elif l.startswith(b"KLEE: done:"):
+      pass
+    elif l.startswith(b"KLEE: ERROR:") and b"unreachable" in l:
+      return status_reachable
+    elif l.startswith(b"KLEE: ERROR:") and b"overflow" in l:
+      return status_overflow
+    elif l.startswith(b"KLEE: ERROR:"):
+      print(l)
+      if verbose: print(stderr.decode("utf-8"))
+      return status_error
+    elif l != b'':
+      print(l)
+      return status_unknown
+
+  if process.returncode != 0:
+    return status_unknown
+
+  return None
+
+
+def main():
+  # todo: worlds worst command line parsing!
+  if sys.argv[1] == "-v":
+    global verbose # How do I hate Python? Let me count the ways.
+    verbose = True
+    del sys.argv[1]
+    print("Verbose mode enabled")
+  test = sys.argv[1]
+
+  status = runtest_honest(test)
+  if  status: print(status)
+  exit(0) # exit status doesn't seem to be important, but use 0
+
+if __name__=="__main__":
+  main()

--- a/benchmarks/smack-regressions/functions/closure.rs
+++ b/benchmarks/smack-regressions/functions/closure.rs
@@ -10,7 +10,7 @@ where
 
 pub fn main() {
     let mut num = verifier::nondet!(5i32);
-    verifier::assume!(num <= std::i32::MAX - 5); // avoid overflow
+    verifier::assume!(num <= std::i32::MAX - 6); // avoid overflow
     let original_num = num;
     {
         let mut add_num = |x: i32| num += x;

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -10,4 +10,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mirai-annotations = "1.6.0"
+
+[features]
+verifier-klee = []
+
+[build]
+rustflags = ["-C", "embed-bitcode=yes"]
+
+[profile.dev]
+codegen-units = 1

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -1,8 +1,85 @@
+#![feature(panic_info_message)]
+
+use core::panic::PanicInfo;
+use std::os::raw;
+use std::ffi::CString;
+use std::default::Default;
+use std::fmt::Write;
+
+pub fn verifier_assume(cond: bool) {
+    extern "C" { fn klee_assume(cond: usize); }
+    unsafe { klee_assume(if cond {1} else {0}) }
+}
+
+pub fn verifier_verify(cond: bool) {
+    if !cond {
+        report_error("verification failed")
+    }
+}
+
+pub fn verifier_abstract_value<T: Default>(_t: T) -> T {
+    extern "C" { fn klee_make_symbolic(data: *mut raw::c_void, length: usize, name: *const raw::c_char); }
+
+    let mut r = T::default();
+    unsafe {
+        let data   = std::mem::transmute(&mut r);
+        let length = std::mem::size_of::<T>();
+        let null = 0 as *const i8;
+        klee_make_symbolic(data, length, null)
+    }
+    return r;
+}
+
+extern "C" {
+    fn klee_report_error(file: *const raw::c_char, line: usize, message: *const raw::c_char, suffix: *const raw::c_char) -> !;
+}
+
+pub fn report_error(message: &str) -> ! {
+    let null = 0 as *const i8;
+    let file = null; // ignored by KLEE
+    let line = 0;    // ignored by KLEE
+    let suffix = ""; // ignored by KLEE
+
+    unsafe {
+        klee_report_error(file,
+                          line,
+                          CString::new(message).unwrap().as_ptr(),
+                          CString::new(suffix).unwrap().as_ptr())
+    }
+}
+
+fn panic_hook(info: &PanicInfo) {
+    let mut msg = String::new();
+    match info.message() {
+        None => msg.write_str("panic"),
+        Some(m) => msg.write_fmt(*m)
+    }.unwrap();
+
+    let null = 0 as *const i8;
+    let file = null; // ignored by KLEE
+    let line = 0;    // ignored by KLEE
+    let suffix = ""; // ignored by KLEE
+
+    unsafe {
+        klee_report_error(file,
+                          line,
+                          CString::new(msg).unwrap().as_ptr(),
+                          CString::new(suffix).unwrap().as_ptr())
+    }
+}
+
+// Calling this before starting verification ensures that
+// panic messages are displayed by KLEE.
+pub fn set_panic_hook() {
+    std::panic::set_hook(Box::new(panic_hook))
+}
+
+
 #[macro_export]
 macro_rules! assume {
     ($condition:expr) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_assume($condition)
+        if cfg!(feature = "verifier-klee") {
+            $crate::verifier_assume($condition)
         } else {
             assert!($condition);
         }
@@ -12,8 +89,8 @@ macro_rules! assume {
 #[macro_export]
 macro_rules! assert {
     ($condition:expr) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_verify($condition, "false verification condition")
+        if cfg!(feature = "verifier-klee") {
+            $crate::verifier_verify($condition)
         } else {
             assert!($condition);
         }
@@ -23,8 +100,8 @@ macro_rules! assert {
 #[macro_export]
 macro_rules! assert_eq {
     ($left:expr, $right:expr) => (
-        if cfg!(mirai) {
-            mirai_annotations::mirai_verify($left == $right, concat!("false verification condition: ", stringify!($left == $right)))
+        if cfg!(feature = "verifier-klee") {
+            $crate::verifier_verify($left == $right)
         } else {
             assert_eq!($left, $right);
         }
@@ -34,10 +111,10 @@ macro_rules! assert_eq {
 #[macro_export]
 macro_rules! assert_ne {
     ($left:expr, $right:expr) => (
-        if cfg!(mirai) {
-            mirai_annotations::mirai_verify($left != $right, concat!("false verification condition: ", stringify!($left != $right)))
+        if cfg!(feature = "verifier-klee") {
+            $crate::verifier_verify($left != $right)
         } else {
-            assert_ne!($left, $right);
+            assert!($left != $right);
         }
     );
 }
@@ -45,8 +122,8 @@ macro_rules! assert_ne {
 #[macro_export]
 macro_rules! unreachable {
     () => (
-        if cfg!(mirai) {
-            panic!("statement is reachable");
+        if cfg!(feature = "verifier-klee") {
+            $crate::report_error("unreachable");
         } else {
             unreachable!();
         }
@@ -56,8 +133,8 @@ macro_rules! unreachable {
 #[macro_export]
 macro_rules! nondet {
     ($value:expr) => {
-        if cfg!(mirai) {
-            mirai_annotations::mirai_abstract_value($value)
+        if cfg!(feature = "verifier-klee") {
+            $crate::verifier_abstract_value($value)
         } else {
             $value
         }


### PR DESCRIPTION
This set of three commits adds KLEE support for these benchmarks.
That is, it does the following

- It rewrites the verifier crate to use KLEE builtins instead of using MIRAI builtins.
- It rewrites the run-mirai script to invoke KLEE instead of MIRAI or SMACK.
  Since KLEE does not necessarily explore all paths, this may not be sound (it may miss some bugs).
  This is ok for me because my goal is to be able to easily switch between tools that
   make different tradeoffs between performance and soundness.
- A minor patch of a hardwired filename

This set of commits is almost certainly not suitable for merging as they are.
But this seemed like the easiest way to share them with you so that we can
decide whether any part of the commits would be useful.