### PR TITLE
Fixed Values of Loops Benchmark

### DIFF
--- a/benchmarks/smack-regressions/loops/gauss_sum_nondet.rs
+++ b/benchmarks/smack-regressions/loops/gauss_sum_nondet.rs
@@ -3,7 +3,7 @@
 
 pub fn main() {
     let mut sum = 0;
-    let b = verifier::nondet!(7u64);
+    let b = verifier::nondet!(4u64);
     verifier::assume!(b < 5 && b > 1);
     for i in 0..b as u64 {
         sum += i;

--- a/benchmarks/smack-regressions/loops/iterator.rs
+++ b/benchmarks/smack-regressions/loops/iterator.rs
@@ -11,7 +11,7 @@ fn fac(n: u64) -> u64 {
 
 pub fn main() {
     let mut a = 1;
-    let n = verifier::nondet!(6u64);
+    let n = verifier::nondet!(4u64);
     verifier::assume!(n < 5);
     for i in 1..n + 1 as u64 {
         a *= i;


### PR DESCRIPTION
I was playing around with the benchmarks individually and noticed that the verifiers were failing both correct examples from the loops benchmark.
Found that the nondet standard values were above the assumed range which triggered an auto-panic.

Alternatively increasing the assumed upper bound should work.